### PR TITLE
Update build target and dependencies for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,13 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: armv7-unknown-linux-gnueabihf
           override: true
 
       - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross
 
       - name: Build for iRock Mobile Programmer (armv7)
-        run: cross build --release --target=armv7-unknown-linux-gnueabihf
+        run: cross build --release --target=aarch64-unknown-linux-gnu
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ edition = "2024"
 cursive = "0.21.1"
 nix = { version = "0.30.1", features = ["process"] }
 octocrab = "0.44.1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json"] }
 self_update = "0.42.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.141"
 tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
-
 tempfile = "3.20.0"
 futures-util = "0.3"
+
+[dependencies.openssl-sys]
+version = "0.9"
+features = ["vendored"]


### PR DESCRIPTION
Changed the release build target from armv7-unknown-linux-gnueabihf to aarch64-unknown-linux-gnu in the GitHub Actions workflow. Updated Cargo.toml to remove the 'rustls-tls' feature from reqwest and added openssl-sys with the 'vendored' feature to dependencies.