### PR TITLE
Add modular flash and hardware support with new UI

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,0 +1,297 @@
+use crate::hardware::HardwareType;
+use std::sync::mpsc;
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+pub struct FlashReleaseService {
+    state: Arc<Mutex<FlashReleaseState>>,
+}
+
+#[derive(Default)]
+struct FlashReleaseState {
+    last_hw_type: Option<HardwareType>,
+    releases: Option<Arc<Vec<Release>>>,
+    releases_loading: bool,
+    releases_error: Option<String>,
+    releases_rx: Option<Receiver<Result<Vec<Release>, Box<dyn std::error::Error + Send + Sync>>>>,
+}
+
+impl FlashReleaseService {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FlashReleaseState::default())),
+        }
+    }
+
+    pub fn set_hw_type(&self, hw_type: Option<HardwareType>) {
+        let mut state = self.state.lock().unwrap();
+        if state.last_hw_type != hw_type {
+            state.last_hw_type = hw_type;
+            state.releases = None;
+            state.releases_error = None;
+            state.releases_loading = false;
+            state.releases_rx = None;
+        }
+    }
+
+    pub fn poll(&self) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(hw_type) = state.last_hw_type {
+            if state.releases.is_none() && state.releases_rx.is_none() && !state.releases_loading {
+                let repo = hw_type.repo();
+                state.releases_loading = true;
+                state.releases_error = None;
+                let (tx, rx) = mpsc::channel();
+                let repo = repo.to_string();
+                std::thread::spawn(move || {
+                    let result = crate::flash::fetch_releases(&repo);
+                    let _ = tx.send(result);
+                });
+                state.releases_rx = Some(rx);
+            }
+        }
+
+        if let Some(rx) = &state.releases_rx {
+            match rx.try_recv() {
+                Ok(result) => {
+                    state.releases_loading = false;
+                    state.releases_rx = None;
+                    match result {
+                        Ok(releases) => state.releases = Some(Arc::new(releases)),
+                        Err(e) => state.releases_error = Some(format!("Fehler: {}", e)),
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    state.releases_loading = false;
+                    state.releases_rx = None;
+                    state.releases_error = Some("Fehler beim Laden der Firmware".to_string());
+                }
+            }
+        }
+    }
+
+    pub fn get_state(&self) -> (Option<Arc<Vec<Release>>>, bool, Option<String>) {
+        let state = self.state.lock().unwrap();
+        (
+            state.releases.clone(),
+            state.releases_loading,
+            state.releases_error.clone(),
+        )
+    }
+}
+use std::path::PathBuf;
+
+// Asset von GitHub herunterladen und temporär speichern, mit Fortschritt für GUI
+pub fn download_github_asset_progress_gui<F>(
+    repo: &str,
+    tag: &str,
+    asset_name: &str,
+    mut progress_cb: F,
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>>
+where
+    F: FnMut(usize) + Send + 'static,
+{
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+    let parts: Vec<&str> = repo.split('/').collect();
+    if parts.len() != 2 {
+        return Err("Ungültiges Repository-Format".into());
+    }
+    let owner = parts[0];
+    let repo_name = parts[1];
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let asset_url = rt.block_on(async {
+        let octocrab = octocrab::Octocrab::default();
+        let release = octocrab
+            .repos(owner, repo_name)
+            .releases()
+            .get_by_tag(tag)
+            .await?;
+        let asset = release
+            .assets
+            .iter()
+            .find(|a| a.name == asset_name)
+            .ok_or_else(|| format!("Asset '{}' nicht gefunden", asset_name))?;
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(asset.browser_download_url.clone())
+    })?;
+    // Asset herunterladen mit Fortschritt
+    let response = rt.block_on(async { reqwest::get(asset_url).await })?;
+    let total = response.content_length().unwrap_or(0);
+    let mut downloaded = 0u64;
+    let dir = tempdir()?;
+    let file_path = dir.path().join(asset_name);
+    let mut file = File::create(&file_path)?;
+    let mut stream = response;
+    loop {
+        let chunk = rt.block_on(async { stream.chunk().await })?;
+        if let Some(chunk) = chunk {
+            file.write_all(&chunk)?;
+            downloaded += chunk.len() as u64;
+            let percent = if total > 0 {
+                (downloaded as f32 / total as f32 * 100.0) as usize
+            } else {
+                0
+            };
+            progress_cb(percent);
+        } else {
+            break;
+        }
+    }
+    // tempdir lebt nur solange wie das TempDir-Objekt, daher Pfad kopieren
+    let final_path = std::env::temp_dir().join(asset_name);
+    std::fs::copy(&file_path, &final_path)?;
+    Ok(final_path)
+}
+
+pub fn fetch_releases(
+    repo: &str,
+) -> Result<Vec<Release>, Box<dyn std::error::Error + Send + Sync>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async_fetch_releases(repo))
+}
+
+async fn async_fetch_releases(
+    repo: &str,
+) -> Result<Vec<Release>, Box<dyn std::error::Error + Send + Sync>> {
+    let parts: Vec<&str> = repo.split('/').collect();
+    if parts.len() != 2 {
+        return Err("Ungültiges Repository-Format".into());
+    }
+    let owner = parts[0];
+    let repo_name = parts[1];
+
+    let octocrab = octocrab::Octocrab::default();
+    let response = octocrab
+        .repos(owner, repo_name)
+        .releases()
+        .list()
+        .per_page(100)
+        .send()
+        .await?;
+
+    let mut filtered_releases = Vec::new();
+    for r in response.items {
+        let stm32_assets: Vec<String> = r
+            .assets
+            .iter()
+            .filter_map(|a| {
+                let name = &a.name;
+                if name.ends_with(".bin") || name.ends_with(".hex") || name.ends_with(".dfu") {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !stm32_assets.is_empty() {
+            filtered_releases.push(Release {
+                tag_name: r.tag_name,
+                prerelease: r.prerelease,
+                stm32_assets,
+            });
+        }
+    }
+    Ok(filtered_releases)
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Release {
+    pub tag_name: String,
+    pub prerelease: bool,
+    pub stm32_assets: Vec<String>,
+}
+
+/// Führt den Flash-Vorgang mit st-flash aus
+pub fn flash_with_st_flash(firmware_path: &str) -> String {
+    let output = std::process::Command::new("st-flash")
+        .arg("write")
+        .arg(firmware_path)
+        .arg("0x08000000")
+        .output();
+    match output {
+        Ok(out) if out.status.success() => {
+            format!(
+                "Flash erfolgreich!\n\n{}",
+                String::from_utf8_lossy(&out.stdout)
+            )
+        }
+        Ok(out) => {
+            format!(
+                "Fehler beim Flashen!\n\n{}",
+                String::from_utf8_lossy(&out.stderr)
+            )
+        }
+        Err(e) => format!("Fehler beim Starten von st-flash: {}", e),
+    }
+}
+
+// Modul für Flash-Logik und Datenabruf
+pub struct FlashConfig {
+    // Beispiel: Pfad zur Firmware-Datei
+    pub firmware_path: String,
+    // Weitere Konfigurationsoptionen hier
+}
+
+pub struct FlashResult {
+    pub success: bool,
+    pub message: String,
+}
+
+/// Führt den Flash-Vorgang aus
+pub fn flash_hardware(config: &FlashConfig) -> FlashResult {
+    // TODO: Implementierung des Flash-Vorgangs
+    FlashResult {
+        success: true,
+        message: "Flash erfolgreich (Platzhalter)".to_string(),
+    }
+}
+
+/// Ruft die benötigten Daten für das Flashen ab
+pub fn fetch_flash_data() -> Result<String, String> {
+    // TODO: Implementierung des Datenabrufs
+    Ok("Daten abgerufen (Platzhalter)".to_string())
+}
+use std::sync::mpsc::Sender;
+
+pub enum DownloadMsg {
+    Progress(usize),
+    Done(String),
+    Error(String),
+}
+
+pub struct FirmwareDownloadHandle {
+    pub rx: Receiver<DownloadMsg>,
+}
+
+impl FirmwareDownloadHandle {
+    pub fn start(repo: String, tag: String, asset: String) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let tx_progress = tx.clone();
+            let res = crate::flash::download_github_asset_progress_gui(
+                &repo,
+                &tag,
+                &asset,
+                move |percent| {
+                    let _ = tx_progress.send(DownloadMsg::Progress(percent));
+                },
+            );
+            match res {
+                Ok(path) => {
+                    let _ = tx.send(DownloadMsg::Done(path.display().to_string()));
+                }
+                Err(e) => {
+                    let _ = tx.send(DownloadMsg::Error(format!("Fehler: {}", e)));
+                }
+            }
+        });
+        FirmwareDownloadHandle { rx }
+    }
+}

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -1,0 +1,42 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HardwareType {
+    IRock424,
+    IRock212,
+    IRock200,
+    IRock300,
+    IRock400,
+}
+
+impl HardwareType {
+    pub fn repo(&self) -> &'static str {
+        match self {
+            HardwareType::IRock424 => "Arvernus/iRock-424",
+            HardwareType::IRock212 => "Arvernus/iRock-212",
+            HardwareType::IRock200 | HardwareType::IRock300 | HardwareType::IRock400 => {
+                "Arvernus/iRock-200-300-400"
+            }
+        }
+    }
+    pub fn all() -> &'static [HardwareType] {
+        &[
+            HardwareType::IRock424,
+            HardwareType::IRock212,
+            HardwareType::IRock200,
+            HardwareType::IRock300,
+            HardwareType::IRock400,
+        ]
+    }
+}
+
+impl std::fmt::Display for HardwareType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            HardwareType::IRock424 => "iRock 424",
+            HardwareType::IRock212 => "iRock 212",
+            HardwareType::IRock200 => "iRock 200",
+            HardwareType::IRock300 => "iRock 300",
+            HardwareType::IRock400 => "iRock 400",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,536 +1,274 @@
-// Für Progressbar-Animation
-use eframe::{App, Frame, NativeOptions, egui};
-use std::sync::mpsc::{self, Receiver, Sender};
-use std::thread;
-use std::time::{Duration, Instant};
+mod hardware;
+use eframe::egui;
+use hardware::HardwareType;
 
-enum GuiJob {
-    ReleasesResult(Result<Vec<Release>, String>),
-    AssetProgress(usize),
-    AssetResult(Result<String, String>),
-    FlashResult(String),
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct SelectedFirmware {
+    tag: String,
+    asset: String,
 }
 
-struct GuiApp {
-    show_info: bool,
-    show_update: bool,
-    show_restart_msg: Option<String>,
-    hardware_types: Vec<HardwareType>,
-    selected_hardware: Option<HardwareType>,
-    releases: Vec<Release>,
-    releases_loading: bool,
-    releases_error: Option<String>,
-    selected_release: Option<Release>,
-    hw_versions: Vec<String>,
-    selected_hw_version: Option<String>,
-    asset_downloading: bool,
-    asset_progress: usize,
-    asset_error: Option<String>,
-    asset_path: Option<String>,
-    flashing: bool,
-    flash_result: Option<String>,
-    update_result: Option<String>,
-    jobs: Vec<GuiJob>,
-    job_sender: Option<Sender<GuiJob>>,
-    job_receiver: Option<Receiver<GuiJob>>,
-    progress_start: Option<Instant>,
+struct MyApp {
+    active_view: View,
+    selected_hw_type: Option<HardwareType>,
+    flash_release_service: flash::FlashReleaseService,
+    selected_firmware: Option<SelectedFirmware>,
+    download_handle: Option<flash::FirmwareDownloadHandle>,
+    download_progress: Option<usize>,
+    download_done: bool,
+    download_error: Option<String>,
+    downloaded_path: Option<String>,
+    flash_result_message: Option<String>,
 }
 
-impl Default for GuiApp {
+impl Default for MyApp {
     fn default() -> Self {
-        let (tx, rx) = mpsc::channel();
         Self {
-            show_info: false,
-            show_update: false,
-            show_restart_msg: None,
-            hardware_types: HardwareType::all().to_vec(),
-            selected_hardware: None,
-            releases: vec![],
-            releases_loading: false,
-            releases_error: None,
-            selected_release: None,
-            hw_versions: vec![],
-            selected_hw_version: None,
-            asset_downloading: false,
-            asset_progress: 0,
-            asset_error: None,
-            asset_path: None,
-            flashing: false,
-            flash_result: None,
-            update_result: None,
-            jobs: Vec::new(),
-            job_sender: Some(tx),
-            job_receiver: Some(rx),
-            progress_start: None,
+            active_view: View::default(),
+            selected_hw_type: None,
+            flash_release_service: flash::FlashReleaseService::new(),
+            selected_firmware: None,
+            download_handle: None,
+            download_progress: None,
+            download_done: false,
+            download_error: None,
+            downloaded_path: None,
+            flash_result_message: None,
         }
     }
 }
+mod flash;
 
-impl App for GuiApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
-        // Verarbeite alle Jobs aus dem Channel
-        if let Some(rx) = &self.job_receiver {
-            while let Ok(job) = rx.try_recv() {
-                match job {
-                    GuiJob::ReleasesResult(res) => {
-                        self.releases_loading = false;
-                        match res {
-                            Ok(releases) => self.releases = releases,
-                            Err(e) => self.releases_error = Some(e),
-                        }
-                    }
-                    GuiJob::AssetProgress(p) => {
-                        self.asset_progress = p;
-                    }
-                    GuiJob::AssetResult(res) => {
-                        self.asset_downloading = false;
-                        match res {
-                            Ok(path) => self.asset_path = Some(path),
-                            Err(e) => self.asset_error = Some(e),
-                        }
-                    }
-                    GuiJob::FlashResult(msg) => {
-                        self.flashing = false;
-                        self.flash_result = Some(msg);
-                    }
-                }
-            }
-        }
+#[derive(PartialEq)]
+enum View {
+    Flash,
+    SetSerial,
+    SetCapacity,
+    ReadSystem,
+    AppUpdate,
+    About,
+    Settings,
+    Help,
+}
 
+// Standard‑View ist Flash
+impl Default for View {
+    fn default() -> Self {
+        View::Flash
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Menüleiste
         egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
-                ui.menu_button(egui::RichText::new("iRockProgrammer").strong(), |ui| {
-                    if ui.button("Über iRockProgrammer").clicked() {
-                        self.show_info = true;
-                        ui.close();
+                ui.menu_button("Device", |ui| {
+                    if ui.button("Flash").clicked() {
+                        self.active_view = View::Flash;
                     }
-                    if ui.button("iRockProgrammer aktualisieren").clicked() {
-                        self.show_update = true;
-                        ui.close();
+                    if ui.button("Set serial number").clicked() {
+                        self.active_view = View::SetSerial;
                     }
-                    if ui.button("iRockProgrammer beenden").clicked() {
-                        std::process::exit(0);
+                    if ui.button("Set capacity").clicked() {
+                        self.active_view = View::SetCapacity;
+                    }
+                    if ui.button("Read system values").clicked() {
+                        self.active_view = View::ReadSystem;
+                    }
+                });
+                ui.menu_button("App", |ui| {
+                    if ui.button("Update app").clicked() {
+                        self.active_view = View::AppUpdate;
+                    }
+                    if ui.button("About").clicked() {
+                        self.active_view = View::About;
+                    }
+                });
+                ui.menu_button("Settings", |ui| {
+                    if ui.button("Settings").clicked() {
+                        self.active_view = View::Settings;
+                    }
+                });
+                ui.menu_button("Help", |ui| {
+                    if ui.button("Manual").clicked() {
+                        self.active_view = View::Help;
                     }
                 });
             });
         });
 
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("iRock Programmer");
-            if let Some(msg) = &self.show_restart_msg {
-                ui.label(msg);
-                if ui.button("OK").clicked() {
-                    self.show_restart_msg = None;
-                }
-                return;
-            }
-
-            // Hardware-Auswahl
-            if self.selected_hardware.is_none() {
-                ui.label("Bitte Hardware-Typ auswählen:");
-                for hw in &self.hardware_types {
-                    if ui.button(hw.to_string()).clicked() {
-                        self.selected_hardware = Some(*hw);
-                        self.releases_loading = true;
-                        self.progress_start = Some(Instant::now());
-                        self.releases_error = None;
-                        let repo = hw.repo().to_string();
-                        let tx = ctx.clone();
-                        let sender = self.job_sender.as_ref().unwrap().clone();
-                        thread::spawn(move || {
-                            let result = fetch_releases(&repo).map_err(|e| format!("{}", e));
-                            let _ = sender.send(GuiJob::ReleasesResult(result));
-                            tx.request_repaint();
-                        });
-                    }
-                }
-                return;
-            }
-
-            // Releases laden
-            if self.releases_loading {
-                // Animierte Progressbar
-                let percent = if let Some(start) = self.progress_start {
-                    let elapsed = start.elapsed().as_secs_f32();
-                    // 2 Sekunden für 100%
-                    (elapsed / 2.0).min(1.0)
-                } else {
-                    0.0
-                };
-                ui.label("Lade Releases...");
-                ui.add(egui::ProgressBar::new(percent).show_percentage());
-                ctx.request_repaint_after(Duration::from_millis(50));
-                return;
-            } else {
-                self.progress_start = None;
-            }
-            if let Some(e) = &self.releases_error {
-                ui.colored_label(egui::Color32::RED, e);
-                if ui.button("Zurück").clicked() {
-                    self.selected_hardware = None;
-                    self.releases.clear();
-                    self.releases_error = None;
-                }
-                return;
-            }
-            if self.selected_release.is_none() {
-                ui.label("Bitte Software-Version auswählen:");
-                for release in &self.releases {
-                    let display = format!(
-                        "{}{}",
-                        release.tag_name,
-                        if release.prerelease {
-                            " (pre-release)"
-                        } else {
-                            ""
+        // Zentraler Content
+        egui::CentralPanel::default().show(ctx, |ui| match self.active_view {
+            View::Flash => {
+                ui.heading("Flash device");
+                ui.separator();
+                ui.label("1. Select hardware type:");
+                let mut hw_type_changed = false;
+                ui.horizontal(|ui| {
+                    for hw_type in HardwareType::all().iter() {
+                        let selected = self.selected_hw_type == Some(*hw_type);
+                        if ui.selectable_label(selected, hw_type.to_string()).clicked() {
+                            if self.selected_hw_type != Some(*hw_type) {
+                                self.selected_hw_type = Some(*hw_type);
+                                hw_type_changed = true;
+                            }
                         }
-                    );
-                    if ui.button(&display).clicked() {
-                        self.selected_release = Some(release.clone());
-                        // Hardware-Versionen extrahieren
-                        let mut hw_versions = vec![];
-                        for asset in &release.stm32_assets {
-                            if let Some((name, ext)) = asset.rsplit_once('.') {
-                                if ext == "bin" || ext == "hex" {
-                                    if let Some((_, hw)) = name.rsplit_once('-') {
-                                        hw_versions.push(hw.to_string());
+                    }
+                });
+
+                // Service informieren
+                self.flash_release_service
+                    .set_hw_type(self.selected_hw_type);
+                self.flash_release_service.poll();
+
+                if self.selected_hw_type.is_some() {
+                    let (releases, releases_loading, releases_error) =
+                        self.flash_release_service.get_state();
+                    ui.add_space(16.0);
+                    ui.label("2. Select firmware:");
+                    if releases_loading {
+                        ui.label("Loading firmware...");
+                    } else if let Some(err) = &releases_error {
+                        ui.colored_label(egui::Color32::RED, err);
+                    } else if let Some(releases) = &releases {
+                        if releases.is_empty() {
+                            ui.label("No firmware found.");
+                        } else {
+                            for release in releases.iter() {
+                                ui.collapsing(
+                                    format!(
+                                        "{}{}",
+                                        release.tag_name,
+                                        if release.prerelease {
+                                            " (Pre-release)"
+                                        } else {
+                                            ""
+                                        }
+                                    ),
+                                    |ui| {
+                                        for asset in &release.stm32_assets {
+                                            let is_selected = if let Some(sel) =
+                                                &self.selected_firmware
+                                            {
+                                                sel.tag == release.tag_name && sel.asset == *asset
+                                            } else {
+                                                false
+                                            };
+                                            if ui.selectable_label(is_selected, asset).clicked() {
+                                                // Wenn eine neue Firmware gewählt wird, alles zurücksetzen
+                                                self.selected_firmware = Some(SelectedFirmware {
+                                                    tag: release.tag_name.clone(),
+                                                    asset: asset.clone(),
+                                                });
+                                                self.download_progress = None;
+                                                self.download_done = false;
+                                                self.download_error = None;
+                                                self.downloaded_path = None;
+                                                self.download_handle = None;
+                                            }
+                                        }
+                                    },
+                                );
+                            }
+                        }
+                        if let Some(sel) = &self.selected_firmware {
+                            if self.download_handle.is_none()
+                                && self.download_progress.is_none()
+                                && self.download_error.is_none()
+                                && !self.download_done
+                            {
+                                if let Some(hw) = self.selected_hw_type {
+                                    let repo = hw.repo().to_string();
+                                    let tag = sel.tag.clone();
+                                    let asset = sel.asset.clone();
+                                    self.download_progress = Some(0); // Progressbar sofort anzeigen
+                                    self.download_handle = Some(
+                                        flash::FirmwareDownloadHandle::start(repo, tag, asset),
+                                    );
+                                }
+                            }
+                            // Download-Progressbar und Flash-Button
+                            if let Some(handle) = &mut self.download_handle {
+                                while let Ok(msg) = handle.rx.try_recv() {
+                                    match msg {
+                                        flash::DownloadMsg::Progress(p) => {
+                                            self.download_progress = Some(p);
+                                        }
+                                        flash::DownloadMsg::Done(path) => {
+                                            self.download_done = true;
+                                            self.downloaded_path = Some(path);
+                                        }
+                                        flash::DownloadMsg::Error(e) => {
+                                            self.download_error = Some(e);
+                                        }
                                     }
                                 }
                             }
-                        }
-                        hw_versions.sort();
-                        hw_versions.dedup();
-                        self.hw_versions = hw_versions;
-                    }
-                }
-                if ui.button("Zurück").clicked() {
-                    self.selected_hardware = None;
-                    self.releases.clear();
-                }
-                return;
-            }
-            if self.selected_hw_version.is_none() {
-                ui.label("Bitte Hardware-Version auswählen:");
-                for hw in &self.hw_versions {
-                    if ui.button(hw).clicked() {
-                        self.selected_hw_version = Some(hw.clone());
-                    }
-                }
-                if ui.button("Zurück").clicked() {
-                    self.selected_release = None;
-                    self.hw_versions.clear();
-                }
-                return;
-            }
-            // Asset-Download
-            if self.asset_path.is_none() && !self.asset_downloading {
-                if ui.button("Firmware herunterladen").clicked() {
-                    self.asset_downloading = true;
-                    self.asset_progress = 0;
-                    self.asset_error = None;
-                    let repo = self.selected_hardware.unwrap().repo().to_string();
-                    let tag = self.selected_release.as_ref().unwrap().tag_name.clone();
-                    let hw = self.selected_hw_version.as_ref().unwrap().clone();
-                    let assets = &self.selected_release.as_ref().unwrap().stm32_assets;
-                    let asset_name = assets.iter().find(|a| a.contains(&hw)).cloned();
-                    let tx = ctx.clone();
-                    let sender = self.job_sender.as_ref().unwrap().clone();
-                    thread::spawn(move || {
-                        if let Some(asset_name) = asset_name {
-                            let result =
-                                download_github_asset_progress_gui(&repo, &tag, &asset_name, {
-                                    let sender = sender.clone();
-                                    let tx = tx.clone();
-                                    move |progress| {
-                                        let _ = sender.send(GuiJob::AssetProgress(progress));
-                                        tx.request_repaint();
+                            if let Some(progress) = self.download_progress {
+                                if !self.download_done {
+                                    ui.label("Downloading...");
+                                    ui.add(
+                                        egui::ProgressBar::new(progress as f32 / 100.0)
+                                            .show_percentage(),
+                                    );
+                                } else if self.download_done {
+                                    ui.label("Download complete.");
+                                    ui.add_space(16.0);
+                                    ui.label("3. Flash firmware:");
+                                    if ui.button("Start flashing firmware now").clicked() {
+                                        if let Some(path) = &self.downloaded_path {
+                                            let result = flash::flash_with_st_flash(path);
+                                            self.flash_result_message = Some(result);
+                                        }
                                     }
-                                })
-                                .map(|p| p.display().to_string())
-                                .map_err(|e| format!("{}", e));
-                            let _ = sender.send(GuiJob::AssetResult(result));
-                            tx.request_repaint();
+                                    if let Some(msg) = &self.flash_result_message {
+                                        ui.add_space(8.0);
+                                        ui.label(msg);
+                                    }
+                                }
+                            }
+                            if let Some(err) = &self.download_error {
+                                ui.colored_label(egui::Color32::RED, err);
+                            }
                         }
-                    });
-                }
-            }
-            if self.asset_downloading {
-                ui.label("Lade Asset herunter...");
-                ui.add(
-                    egui::ProgressBar::new(self.asset_progress as f32 / 100.0).show_percentage(),
-                );
-                return;
-            }
-            if let Some(e) = &self.asset_error {
-                ui.colored_label(egui::Color32::RED, e);
-                if ui.button("Zurück").clicked() {
-                    self.selected_hw_version = None;
-                    self.asset_error = None;
-                }
-                return;
-            }
-            if let Some(path) = &self.asset_path {
-                ui.label(format!("Asset wurde heruntergeladen: {}", path));
-                if !self.flashing {
-                    if ui.button("Jetzt auf STM32 flashen").clicked() {
-                        self.flashing = true;
-                        self.flash_result = None;
-                        let flash_path = path.clone();
-                        let tx = ctx.clone();
-                        let sender = self.job_sender.as_ref().unwrap().clone();
-                        thread::spawn(move || {
-                            let output = std::process::Command::new("st-flash")
-                                .arg("write")
-                                .arg(&flash_path)
-                                .arg("0x08000000")
-                                .output();
-                            let msg = match output {
-                                Ok(out) if out.status.success() => {
-                                    format!(
-                                        "Flash erfolgreich!\n\n{}",
-                                        String::from_utf8_lossy(&out.stdout)
-                                    )
-                                }
-                                Ok(out) => {
-                                    format!(
-                                        "Fehler beim Flashen!\n\n{}",
-                                        String::from_utf8_lossy(&out.stderr)
-                                    )
-                                }
-                                Err(e) => format!("Fehler beim Starten von st-flash: {}", e),
-                            };
-                            let _ = sender.send(GuiJob::FlashResult(msg));
-                            tx.request_repaint();
-                        });
-                    }
-                } else {
-                    ui.label("Flashe Firmware ...");
-                }
-                if let Some(msg) = &self.flash_result {
-                    ui.label(msg);
-                    if ui.button("Beenden").clicked() {
-                        std::process::exit(0);
                     }
                 }
-                return;
+            }
+            View::SetSerial => {
+                ui.heading("Set serial number");
+            }
+            View::SetCapacity => {
+                ui.heading("Set capacity");
+            }
+            View::ReadSystem => {
+                ui.heading("Read system values");
+            }
+            View::AppUpdate => {
+                ui.heading("App update");
+            }
+            View::About => {
+                ui.heading("About this app");
+                ui.label("BMS Installer Maintenance v0.1");
+            }
+            View::Settings => {
+                ui.heading("Settings");
+            }
+            View::Help => {
+                ui.heading("Help / Manual");
             }
         });
-
-        if self.show_info {
-            egui::Window::new("Info")
-                .open(&mut self.show_info)
-                .show(ctx, |ui| {
-                    ui.label(format!("Version: {}", env!("CARGO_PKG_VERSION")));
-                    ui.label("Programmiere iRock Mobile Geräte");
-                });
-        }
-        // Workaround für Borrow-Checker: show_update-Status lokal puffern
-        let mut show_update = self.show_update;
-        if show_update {
-            egui::Window::new("Update")
-                .open(&mut show_update)
-                .show(ctx, |ui| {
-                    if self.update_result.is_none() {
-                        ui.label("Update wird durchgeführt...");
-                        let sender = self.job_sender.as_ref().unwrap().clone();
-                        let tx = ctx.clone();
-                        thread::spawn(move || {
-                            let result = run_update_and_restart();
-                            let _ = sender.send(GuiJob::FlashResult(match result {
-                                0 => "Update erfolgreich. Bitte neu starten.".to_string(),
-                                _ => "Update fehlgeschlagen.".to_string(),
-                            }));
-                            tx.request_repaint();
-                        });
-                    } else {
-                        ui.label(self.update_result.as_ref().unwrap());
-                        if ui.button("OK").clicked() {
-                            // Wert nach außen zurückschreiben
-                            self.update_result = None;
-                            // show_update wird nach der Closure zurückgeschrieben
-                        }
-                    }
-                });
-            self.show_update = show_update;
-        }
     }
 }
 
-use serde::Deserialize;
-
-mod self_update_mod;
-use self_update_mod::run_update_and_restart;
-
-#[derive(Debug, Deserialize, Clone)]
-struct Release {
-    tag_name: String,
-    prerelease: bool,
-    stm32_assets: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum HardwareType {
-    IRock424,
-    IRock212,
-    IRock200,
-    IRock300,
-    IRock400,
-}
-
-impl HardwareType {
-    fn repo(&self) -> &'static str {
-        match self {
-            HardwareType::IRock424 => "Arvernus/iRock-424",
-            HardwareType::IRock212 => "Arvernus/iRock-212",
-            HardwareType::IRock200 | HardwareType::IRock300 | HardwareType::IRock400 => {
-                "Arvernus/iRock-200-300-400"
-            }
-        }
-    }
-    fn all() -> &'static [HardwareType] {
-        &[
-            HardwareType::IRock424,
-            HardwareType::IRock212,
-            HardwareType::IRock200,
-            HardwareType::IRock300,
-            HardwareType::IRock400,
-        ]
-    }
-}
-
-impl std::fmt::Display for HardwareType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            HardwareType::IRock424 => "iRock 424",
-            HardwareType::IRock212 => "iRock 212",
-            HardwareType::IRock200 => "iRock 200",
-            HardwareType::IRock300 => "iRock 300",
-            HardwareType::IRock400 => "iRock 400",
-        };
-        write!(f, "{}", s)
-    }
-}
-
-fn main() {
-    let options = NativeOptions::default();
-    let _ = eframe::run_native(
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
         "iRock Programmer",
         options,
-        Box::new(|_cc| Ok(Box::<GuiApp>::default())),
-    );
-}
-// Hilfsfunktion: Asset von GitHub herunterladen und temporär speichern, mit Fortschritt für GUI
-fn download_github_asset_progress_gui<F>(
-    repo: &str,
-    tag: &str,
-    asset_name: &str,
-    mut progress_cb: F,
-) -> Result<std::path::PathBuf, Box<dyn std::error::Error + Send + Sync>>
-where
-    F: FnMut(usize) + Send + 'static,
-{
-    use std::fs::File;
-    use std::io::Write;
-    use tempfile::tempdir;
-    let parts: Vec<&str> = repo.split('/').collect();
-    if parts.len() != 2 {
-        return Err("Ungültiges Repository-Format".into());
-    }
-    let owner = parts[0];
-    let repo_name = parts[1];
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?;
-    let asset_url = rt.block_on(async {
-        let octocrab = octocrab::Octocrab::default();
-        let release = octocrab
-            .repos(owner, repo_name)
-            .releases()
-            .get_by_tag(tag)
-            .await?;
-        let asset = release
-            .assets
-            .iter()
-            .find(|a| a.name == asset_name)
-            .ok_or_else(|| format!("Asset '{}' nicht gefunden", asset_name))?;
-        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(asset.browser_download_url.clone())
-    })?;
-    // Asset herunterladen mit Fortschritt
-    let response = rt.block_on(async { reqwest::get(asset_url).await })?;
-    let total = response.content_length().unwrap_or(0);
-    let mut downloaded = 0u64;
-    let dir = tempdir()?;
-    let file_path = dir.path().join(asset_name);
-    let mut file = File::create(&file_path)?;
-    let mut stream = response;
-    loop {
-        let chunk = rt.block_on(async { stream.chunk().await })?;
-        if let Some(chunk) = chunk {
-            file.write_all(&chunk)?;
-            downloaded += chunk.len() as u64;
-            let percent = if total > 0 {
-                (downloaded as f32 / total as f32 * 100.0) as usize
-            } else {
-                0
-            };
-            progress_cb(percent);
-        } else {
-            break;
-        }
-    }
-    // tempdir lebt nur solange wie das TempDir-Objekt, daher Pfad kopieren
-    let final_path = std::env::temp_dir().join(asset_name);
-    std::fs::copy(&file_path, &final_path)?;
-    Ok(final_path)
-}
-
-fn fetch_releases(repo: &str) -> Result<Vec<Release>, Box<dyn std::error::Error + Send + Sync>> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
-    rt.block_on(async_fetch_releases(repo))
-}
-
-async fn async_fetch_releases(
-    repo: &str,
-) -> Result<Vec<Release>, Box<dyn std::error::Error + Send + Sync>> {
-    let parts: Vec<&str> = repo.split('/').collect();
-    if parts.len() != 2 {
-        return Err("Ungültiges Repository-Format".into());
-    }
-    let owner = parts[0];
-    let repo_name = parts[1];
-
-    let octocrab = octocrab::Octocrab::default();
-    let response = octocrab
-        .repos(owner, repo_name)
-        .releases()
-        .list()
-        .per_page(100)
-        .send()
-        .await?;
-
-    let mut filtered_releases = Vec::new();
-    for r in response.items {
-        let stm32_assets: Vec<String> = r
-            .assets
-            .iter()
-            .filter_map(|a| {
-                let name = &a.name;
-                if name.ends_with(".bin") || name.ends_with(".hex") || name.ends_with(".dfu") {
-                    Some(name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !stm32_assets.is_empty() {
-            filtered_releases.push(Release {
-                tag_name: r.tag_name,
-                prerelease: r.prerelease,
-                stm32_assets,
-            });
-        }
-    }
-    Ok(filtered_releases)
+        // ★ Hier muss das Boxed-Closure ein Result zurückgeben! ★
+        Box::new(|_cc| Ok(Box::new(MyApp::default()))),
+    )
 }


### PR DESCRIPTION
Introduces src/flash.rs and src/hardware.rs to modularize firmware flashing and hardware type logic. Refactors main.rs to use these modules, implements a new state-driven UI for firmware selection, download, and flashing, and improves code structure for maintainability and extensibility.