### PR TITLE
Add aarch64 cross toolchain to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           echo "version=$(cargo metadata --format-version=1 --no-deps \
             | jq -r '.packages[] | select(.name=="iRockProgrammer").version')" \
             >> $GITHUB_OUTPUT
+      
+      - name: Install aarch64 cross toolchain
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Installs gcc-aarch64-linux-gnu in the GitHub Actions release workflow to enable cross-compilation for aarch64 targets.