### PR TITLE
Use cross container for aarch64 builds in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build-and-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    container:
+      image: rustembedded/cross:aarch64-unknown-linux-gnu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,9 +35,6 @@ jobs:
             | jq -r '.packages[] | select(.name=="iRockProgrammer").version')" \
             >> $GITHUB_OUTPUT
       
-      - name: Install aarch64 cross toolchain
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -47,15 +46,9 @@ jobs:
           if ! command -v jq &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y jq
           fi
-          if ! command -v cross &> /dev/null; then
-            cargo install cross
-          fi
           if ! command -v cargo-bundle &> /dev/null; then
             cargo install cargo-bundle
           fi
-
-      - name: Build for iRock Mobile Programmer
-        run: cross build --release --target=aarch64-unknown-linux-gnu
 
       - name: Bundle App für Linux Desktop
         run: cargo bundle --release --target aarch64-unknown-linux-gnu


### PR DESCRIPTION
Updated the GitHub Actions release workflow to run inside the rustembedded/cross:aarch64-unknown-linux-gnu container. Removed manual installation of the aarch64 toolchain and cross, simplifying the build process for aarch64 targets.