### PR TITLE
Remove docker.io from release workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies (jq, cross & cargo-bundle)
         run: |
-          sudo apt-get update && sudo apt-get install -y jq docker.io
+          sudo apt-get update && sudo apt-get install -y jq
           cargo install --locked cross cargo-bundle
 
       - name: Cross‑Bundle App für Linux Desktop


### PR DESCRIPTION
The release workflow no longer installs docker.io as a dependency. This simplifies the setup step and may reduce unnecessary package installations.