### PR TITLE
Add step to install aarch64 cross-compiler in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Installiere Cross-Compiler für aarch64
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+        
       - name: Install Rust target aarch64-unknown-linux-gnu
         run: rustup target add aarch64-unknown-linux-gnu
 


### PR DESCRIPTION
Added a step to install the gcc-aarch64-linux-gnu package before adding the Rust aarch64 target. This ensures the necessary cross-compiler is available for building aarch64 binaries.