### PR TITLE
Switch flashing to probe-rs and update release workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-[target.aarch64-unknown-linux-musl]
-linker = "musl-gcc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,22 @@ on:
     types: [ closed ]
 
 jobs:
-  build-and-release:
+  build:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-22.04-arm
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04-arm
+            label: linux-arm64
+            bundle_path: target/release/bundle/deb/*
+          - os: macos-13
+            label: macos
+            bundle_path: target/release/bundle/osx/*
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Cache
-        uses: actions/cache@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -30,17 +37,38 @@ jobs:
       - name: Install cargo-bundle
         run: cargo install cargo-bundle
 
-      - name: Bundle App für Linux
+      - name: Bundle App
         run: cargo bundle --release
 
-      - name: Create Release
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.label }}
+          path: ${{ matrix.bundle_path }}
+
+    outputs:
+      version: ${{ steps.cargo_version.outputs.version }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List all artifacts
+        run: ls -R artifacts
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.cargo_version.outputs.version }}
+          tag_name: v${{ needs.build.outputs.version }}
           name: Release für iRock Mobile Programmer
-          body: "Automatischer Build für iRock Mobile Programmer (aarch64)"
-          files: |
-            target/release/bundle/deb/iRockProgrammer_${{ steps.cargo_version.outputs.version }}_arm64.deb
+          body: |
+            Automatischer Build für iRock Mobile Programmer.
+          files: artifacts/**/*
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iRockProgrammer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["Joscha Wagner <joscha.wagner@example.com>"]
 
@@ -10,11 +10,14 @@ octocrab = "0.44.1"
 reqwest = { version = "0.12", features = ["json"] }
 self_update = "0.42.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.141"
+serde_json = "1.0.142"
 tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
 tempfile = "3.20.0"
 futures-util = "0.3"
 eframe = "0.32.0"
+
+probe-rs = "0.29"
+anyhow = "1.0"
 
 [dependencies.openssl-sys]
 version = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,10 +218,13 @@ impl eframe::App for MyApp {
                                     ui.label("Download complete.");
                                     ui.add_space(16.0);
                                     ui.label("3. Flash firmware:");
-                                    if ui.button("Start flashing firmware now").clicked() {
+                                    if ui.button("Firmware jetzt flashen").clicked() {
                                         if let Some(path) = &self.downloaded_path {
-                                            let result = flash::flash_with_st_flash(path);
-                                            self.flash_result_message = Some(result);
+                                            let config = flash::FlashConfig {
+                                                firmware_path: path.clone(),
+                                            };
+                                            let result = flash::flash_hardware(&config);
+                                            self.flash_result_message = Some(result.message);
                                         }
                                     }
                                     if let Some(msg) = &self.flash_result_message {
@@ -251,7 +254,7 @@ impl eframe::App for MyApp {
             }
             View::About => {
                 ui.heading("About this app");
-                ui.label("BMS Installer Maintenance v0.1");
+                ui.label(format!("iRockProgrammer v{}", env!("CARGO_PKG_VERSION")));
             }
             View::Settings => {
                 ui.heading("Settings");


### PR DESCRIPTION
Removed st-flash support and refactored flashing logic to use probe-rs exclusively. Updated dependencies in Cargo.toml, incremented version to 0.1.3, and improved the GitHub release workflow to support multi-platform builds and artifact uploads. UI now reflects the new flashing method and displays the current app version.