### PR TITLE
Update release workflow and .gitignore entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install libudev-dev (nur Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
       - uses: actions/cache@v4
         with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# iRockProgrammer
+.irock_restart_msg
+
 
 # Added by cargo
 


### PR DESCRIPTION
Adds installation of libudev-dev for Ubuntu in the release workflow to support Linux builds. Also updates .gitignore to exclude .irock_restart_msg for iRockProgrammer.