### PR TITLE
Update release workflow bundle paths and artifact handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - os: ubuntu-22.04-arm
             label: linux-arm64
-            bundle_path: target/release/bundle/deb/*
+            bundle_path: target/release/bundle/deb/*.deb
           - os: macos-13
             label: macos
-            bundle_path: target/release/bundle/osx/*
+            bundle_path: target/release/bundle/osx/*.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Bundle App
         run: cargo bundle --release
 
-      - name: Upload Artifact
+      - name: Upload Bundle
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.label }}
@@ -67,20 +67,6 @@ jobs:
       - name: List all artifacts
         run: ls -R artifacts
 
-      - name: Artefakte umbenennen
-        run: |
-          mkdir -p release
-          for platform in $(find artifacts -mindepth 1 -maxdepth 1 -type d -exec basename {} \;); do
-            if [ -d "artifacts/$platform" ]; then
-              find "artifacts/$platform" -type f -exec bash -c '
-                base=$(basename "$1");
-                ext="${base##*.}";
-                if [ "$ext" = "$base" ]; then ext=""; else ext=".$ext"; fi;
-                mv "$1" "release/${base}_${platform}${ext}"
-              ' _ {} \;
-              rm -r "artifacts/$platform"
-            fi
-          done
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -89,7 +75,7 @@ jobs:
           name: Release für iRock Mobile Programmer
           body: |
             Automatischer Build für iRock Mobile Programmer.
-          files: release/*
+          files: artifacts/*/*
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Refines bundle_path patterns for Linux and macOS to target specific file types. Removes artifact renaming step and updates GitHub Release to use original artifact paths. This streamlines the release process and ensures correct files are uploaded.